### PR TITLE
Release v1.0.3

### DIFF
--- a/.github/workflows/nodejs.yaml
+++ b/.github/workflows/nodejs.yaml
@@ -26,6 +26,7 @@ jobs:
           tag-prefix: 'v'
           release-count: 0
           fallback-version: '1.0.0'
+          skip-on-empty: 'false'
       - name: Create Release
         uses: actions/create-release@v1
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oas-tools/cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oas-tools/cli",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@oas-tools/commons": "^1.0.0",
@@ -102,9 +102,9 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "node_modules/@oas-tools/commons": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@oas-tools/commons/-/commons-1.0.0.tgz",
-      "integrity": "sha512-qLWZlPFxhdgnqEDeYZ9Y6gvw6sxevh7rLnaeAnPIEUmz0mjtkf5KLYXWNk8rWbSrKff+LTlZoqGBfxvMx1l81w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oas-tools/commons/-/commons-1.0.1.tgz",
+      "integrity": "sha512-yMJWl8BtmwDhlKergdYw++nD5LPD+7QC9rkOyTor9A6i9am3bE4Qlu3OXau6yFiG6NDTw+DPrX5nSevEL9FzSw==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",
@@ -1412,9 +1412,9 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@oas-tools/commons": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@oas-tools/commons/-/commons-1.0.0.tgz",
-      "integrity": "sha512-qLWZlPFxhdgnqEDeYZ9Y6gvw6sxevh7rLnaeAnPIEUmz0mjtkf5KLYXWNk8rWbSrKff+LTlZoqGBfxvMx1l81w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@oas-tools/commons/-/commons-1.0.1.tgz",
+      "integrity": "sha512-yMJWl8BtmwDhlKergdYw++nD5LPD+7QC9rkOyTor9A6i9am3bE4Qlu3OXau6yFiG6NDTw+DPrX5nSevEL9FzSw==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-draft-04": "^1.0.0",


### PR DESCRIPTION
Release v1.0.3:
* Updated oas-tools/commons to solve validation error with Node.js v14 caused by: https://github.com/oas-tools/oas-commons/issues/7